### PR TITLE
refactor: decompose FrigateAnalyzerBot into command handler classes

### DIFF
--- a/.claude/rules/telegram.md
+++ b/.claude/rules/telegram.md
@@ -20,7 +20,9 @@ Library: `dev.inmo:tgbotapi` (ktgbotapi)
 
 | Component | Location | Purpose |
 |-----------|----------|---------|
-| FrigateAnalyzerBot | `telegram/bot/` | Main bot, long polling, commands |
+| FrigateAnalyzerBot | `telegram/bot/` | Thin orchestrator: lifecycle, routing, auth, command menus |
+| CommandHandler + handlers | `telegram/bot/handler/` | Command-per-class architecture for bot commands |
+| ExportDialogRunner / ExportExecutor / ActiveExportTracker | `telegram/bot/handler/export/` | `/export` dialog, execution, concurrency guard |
 | TelegramUserService | `telegram/service/` | Manages users (invite, activate, remove) |
 | TelegramNotificationService | `telegram/service/` | Notification interface |
 | TelegramNotificationServiceImpl | `telegram/service/impl/` | Active notification implementation |
@@ -52,10 +54,19 @@ Library: `dev.inmo:tgbotapi` (ktgbotapi)
 |---------|--------|-------------|
 | /start | All | Activate subscription |
 | /help | USER, OWNER | List commands |
+| /export | USER, OWNER | Export camera video |
+| /timezone | USER, OWNER | Configure timezone |
 | /version | USER, OWNER | Show application version |
 | /adduser | OWNER | Invite user |
 | /removeuser | OWNER | Remove user |
 | /users | OWNER | List all users |
+
+## Bot Architecture
+
+- `FrigateAnalyzerBot` registers commands dynamically from `List<CommandHandler>`.
+- Command ordering is controlled by handler metadata (`order`, then command name as tie-breaker).
+- Authorization is centralized in bot router via `AuthorizationFilter.getRole()` and `requiredRole`.
+- Owner menu registration uses `OwnerActivatedEvent` + `@EventListener` bridge with coroutine launch.
 
 ## Authorization
 

--- a/modules/telegram/src/main/kotlin/ru/zinin/frigate/analyzer/telegram/bot/FrigateAnalyzerBot.kt
+++ b/modules/telegram/src/main/kotlin/ru/zinin/frigate/analyzer/telegram/bot/FrigateAnalyzerBot.kt
@@ -1,113 +1,38 @@
 package ru.zinin.frigate.analyzer.telegram.bot
 
 import dev.inmo.tgbotapi.bot.TelegramBot
-import dev.inmo.tgbotapi.extensions.api.answers.answer
 import dev.inmo.tgbotapi.extensions.api.bot.getMe
 import dev.inmo.tgbotapi.extensions.api.bot.setMyCommands
-import dev.inmo.tgbotapi.extensions.api.edit.reply_markup.editMessageReplyMarkup
-import dev.inmo.tgbotapi.extensions.api.edit.text.editMessageText
-import dev.inmo.tgbotapi.extensions.api.send.media.sendVideo
 import dev.inmo.tgbotapi.extensions.api.send.reply
-import dev.inmo.tgbotapi.extensions.api.send.sendTextMessage
 import dev.inmo.tgbotapi.extensions.behaviour_builder.BehaviourContext
 import dev.inmo.tgbotapi.extensions.behaviour_builder.buildBehaviourWithLongPolling
-import dev.inmo.tgbotapi.extensions.behaviour_builder.expectations.waitDataCallbackQuery
-import dev.inmo.tgbotapi.extensions.behaviour_builder.expectations.waitTextMessage
 import dev.inmo.tgbotapi.extensions.behaviour_builder.triggers_handling.onCommand
 import dev.inmo.tgbotapi.extensions.behaviour_builder.triggers_handling.onContentMessage
-import dev.inmo.tgbotapi.requests.abstracts.asMultipartFile
 import dev.inmo.tgbotapi.types.BotCommand
 import dev.inmo.tgbotapi.types.ChatId
-import dev.inmo.tgbotapi.types.IdChatIdentifier
 import dev.inmo.tgbotapi.types.RawChatId
-import dev.inmo.tgbotapi.types.buttons.InlineKeyboardButtons.CallbackDataInlineKeyboardButton
-import dev.inmo.tgbotapi.types.buttons.InlineKeyboardMarkup
 import dev.inmo.tgbotapi.types.commands.BotCommandScopeChat
 import dev.inmo.tgbotapi.types.commands.BotCommandScopeDefault
-import dev.inmo.tgbotapi.types.message.abstracts.CommonMessage
-import dev.inmo.tgbotapi.types.message.abstracts.PrivateContentMessage
-import dev.inmo.tgbotapi.types.message.content.TextContent
-import dev.inmo.tgbotapi.types.queries.callback.MessageDataCallbackQuery
-import dev.inmo.tgbotapi.utils.matrix
-import dev.inmo.tgbotapi.utils.row
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.annotation.PostConstruct
 import jakarta.annotation.PreDestroy
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withTimeoutOrNull
-import org.springframework.beans.factory.ObjectProvider
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.boot.info.BuildProperties
-import org.springframework.boot.info.GitProperties
+import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
+import ru.zinin.frigate.analyzer.telegram.bot.handler.CommandHandler
+import ru.zinin.frigate.analyzer.telegram.bot.handler.OwnerActivatedEvent
 import ru.zinin.frigate.analyzer.telegram.config.TelegramProperties
 import ru.zinin.frigate.analyzer.telegram.filter.AuthorizationFilter
 import ru.zinin.frigate.analyzer.telegram.model.UserRole
-import ru.zinin.frigate.analyzer.telegram.model.UserStatus
 import ru.zinin.frigate.analyzer.telegram.service.TelegramUserService
-import ru.zinin.frigate.analyzer.telegram.service.VideoExportService
-import ru.zinin.frigate.analyzer.telegram.service.model.ExportMode
-import ru.zinin.frigate.analyzer.telegram.service.model.VideoExportProgress
-import ru.zinin.frigate.analyzer.telegram.service.model.VideoExportProgress.Stage
-import java.time.Clock
-import java.time.DateTimeException
-import java.time.Duration
-import java.time.Instant
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.LocalTime
-import java.time.ZoneId
-import java.time.format.DateTimeFormatter
-import java.time.format.DateTimeParseException
-import java.time.temporal.ChronoUnit
-import java.util.concurrent.ConcurrentHashMap
 
 private val logger = KotlinLogging.logger {}
-
-private data class ExportDialogResult(
-    val startInstant: Instant,
-    val endInstant: Instant,
-    val camId: String,
-    val mode: ExportMode,
-)
-
-private fun renderProgress(
-    stage: Stage,
-    percent: Int? = null,
-    mode: ExportMode = ExportMode.ORIGINAL,
-    compressing: Boolean = false,
-): String {
-    val stages =
-        buildList {
-            add(Stage.PREPARING to "Подготовка")
-            add(Stage.MERGING to "Склейка видео")
-            if (compressing) add(Stage.COMPRESSING to "Сжатие видео")
-            if (mode == ExportMode.ANNOTATED) add(Stage.ANNOTATING to "Аннотация видео")
-            add(Stage.SENDING to "Отправка")
-            add(Stage.DONE to "Готово")
-        }
-
-    val currentIndex = stages.indexOfFirst { it.first == stage }
-
-    return buildString {
-        for ((index, pair) in stages.withIndex()) {
-            val (s, label) = pair
-            when {
-                s == stage && s == Stage.DONE -> appendLine("\u2705 $label")
-                s == stage && s == Stage.ANNOTATING && percent != null -> appendLine("\uD83D\uDD04 $label: $percent%")
-                s == stage -> appendLine("\uD83D\uDD04 $label...")
-                currentIndex >= 0 && index < currentIndex -> appendLine("\u2705 $label")
-                else -> appendLine("\u2B1C $label")
-            }
-        }
-    }.trimEnd()
-}
 
 @Component
 @ConditionalOnProperty(prefix = "application.telegram", name = ["enabled"], havingValue = "true")
@@ -116,37 +41,21 @@ class FrigateAnalyzerBot(
     private val authorizationFilter: AuthorizationFilter,
     private val userService: TelegramUserService,
     private val properties: TelegramProperties,
-    private val videoExportService: VideoExportService,
-    private val clock: Clock,
-    private val buildProperties: ObjectProvider<BuildProperties>,
-    private val gitProperties: ObjectProvider<GitProperties>,
+    private val handlers: List<CommandHandler>,
 ) {
     private val botScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
-    private val activeExports: MutableSet<Long> = ConcurrentHashMap.newKeySet()
 
-    companion object {
-        private const val EXPORT_DIALOG_TIMEOUT_MS = 600_000L
-        private const val EXPORT_ORIGINAL_TIMEOUT_MS = 300_000L
-        private const val EXPORT_ANNOTATED_TIMEOUT_MS = 1_200_000L
-        private const val MAX_EXPORT_DURATION_MINUTES = 5L
+    private val sortedHandlers: List<CommandHandler>
+        get() = handlers.sortedWith(compareBy<CommandHandler> { it.order }.thenBy { it.command })
 
-        private val DEFAULT_COMMANDS =
-            listOf(
-                BotCommand("start", "Начать работу с ботом"),
-                BotCommand("help", "Помощь"),
-                BotCommand("export", "Выгрузить видео"),
-                BotCommand("timezone", "Часовой пояс"),
-                BotCommand("version", "Версия приложения"),
-            )
+    private val defaultCommands: List<BotCommand>
+        get() =
+            sortedHandlers
+                .filterNot { it.ownerOnly }
+                .map { BotCommand(it.command, it.description) }
 
-        private val OWNER_COMMANDS =
-            DEFAULT_COMMANDS +
-                listOf(
-                    BotCommand("adduser", "Добавить пользователя"),
-                    BotCommand("removeuser", "Удалить пользователя"),
-                    BotCommand("users", "Список пользователей"),
-                )
-    }
+    private val ownerCommands: List<BotCommand>
+        get() = sortedHandlers.map { BotCommand(it.command, it.description) }
 
     @PostConstruct
     fun start() {
@@ -170,779 +79,71 @@ class FrigateAnalyzerBot(
 
                 bot
                     .buildBehaviourWithLongPolling {
-                        onCommand("start") { message ->
-                            handleStart(message)
-                        }
-
-                        onCommand("help") { message ->
-                            handleHelp(message)
-                        }
-
-                        onCommand("adduser") { message ->
-                            handleAddUser(message)
-                        }
-
-                        onCommand("removeuser") { message ->
-                            handleRemoveUser(message)
-                        }
-
-                        onCommand("users") { message ->
-                            handleUsers(message)
-                        }
-
-                        onCommand("export") { message ->
-                            handleExport(message)
-                        }
-
-                        onCommand("timezone") { message ->
-                            handleTimezone(message)
-                        }
-
-                        onCommand("version") { message ->
-                            handleVersion(message)
-                        }
-
-                        onContentMessage { message ->
-                            val role = authorizationFilter.getRole(message)
-                            if (role == null) {
-                                reply(message, authorizationFilter.getUnauthorizedMessage())
-                                return@onContentMessage
-                            }
-                            // Ignore non-command messages for now
-                        }
+                        registerRoutes()
                     }.join()
+            } catch (e: CancellationException) {
+                logger.info { "Telegram bot long polling cancelled" }
             } catch (e: Exception) {
                 logger.error(e) { "Error in Telegram bot long polling" }
             }
         }
     }
 
-    private suspend fun handleStart(message: CommonMessage<TextContent>) {
-        val privateMessage = message as? PrivateContentMessage<*>
-        val username = privateMessage?.user?.username?.withoutAt
-        if (username == null) {
-            bot.reply(message, "Ошибка: не удалось определить ваш username.")
-            return
-        }
+    private suspend fun BehaviourContext.registerRoutes() {
+        sortedHandlers.forEach { handler ->
+            onCommand(handler.command) { message ->
+                val role: UserRole? =
+                    if (handler.requiredRole != null) {
+                        val resolvedRole = authorizationFilter.getRole(message)
 
-        val chatId = message.chat.id.chatId.long
-        val userId =
-            privateMessage
-                ?.user
-                ?.id
-                ?.chatId
-                ?.long ?: return
-
-        // Check if owner
-        if (username == properties.owner) {
-            // Register owner in DB for notifications
-            val existing = userService.findByUsername(username)
-            if (existing == null) {
-                userService.inviteUser(username)
-            }
-            if (existing?.status != UserStatus.ACTIVE) {
-                userService.activateUser(
-                    username = username,
-                    chatId = chatId,
-                    userId = userId,
-                    firstName = privateMessage.user.firstName,
-                    lastName = privateMessage.user.lastName,
-                )
-            }
-            bot.reply(message, "Добро пожаловать, владелец! Используйте /help для списка команд.")
-            registerOwnerCommands(chatId)
-            return
-        }
-
-        // Check if invited user
-        val user = userService.findByUsername(username)
-        if (user == null) {
-            bot.reply(message, authorizationFilter.getUnauthorizedMessage())
-            return
-        }
-
-        if (user.status == UserStatus.ACTIVE) {
-            bot.reply(message, "Вы уже подписаны на уведомления. Используйте /help для списка команд.")
-            return
-        }
-
-        // Activate invited user
-        val activated =
-            userService.activateUser(
-                username = username,
-                chatId = chatId,
-                userId = userId,
-                firstName = privateMessage.user.firstName,
-                lastName = privateMessage.user.lastName,
-            )
-
-        if (activated != null) {
-            bot.reply(message, "Вы успешно подписались на уведомления! Используйте /help для списка команд.")
-        } else {
-            bot.reply(message, "Ошибка активации. Обратитесь к администратору.")
-        }
-    }
-
-    private suspend fun handleHelp(message: CommonMessage<TextContent>) {
-        val role = authorizationFilter.getRole(message)
-        if (role == null) {
-            bot.reply(message, authorizationFilter.getUnauthorizedMessage())
-            return
-        }
-
-        val helpText =
-            buildString {
-                appendLine("📋 Доступные команды:")
-                appendLine()
-                appendLine("/start - Активация подписки")
-                appendLine("/help - Список команд")
-                appendLine("/export - Выгрузить видео с камеры")
-                appendLine("/timezone - Настроить часовой пояс")
-                appendLine("/version - Версия приложения")
-
-                if (role == UserRole.OWNER) {
-                    appendLine()
-                    appendLine("👑 Команды владельца:")
-                    appendLine("/adduser @username - Пригласить пользователя")
-                    appendLine("/removeuser @username - Удалить пользователя")
-                    appendLine("/users - Список пользователей")
-                }
-            }
-
-        bot.reply(message, helpText)
-    }
-
-    private suspend fun handleAddUser(message: CommonMessage<TextContent>) {
-        if (!authorizationFilter.isOwner(message)) {
-            bot.reply(message, "Эта команда доступна только владельцу.")
-            return
-        }
-
-        val text = message.content.text
-        val parts = text.split(" ", limit = 2)
-        if (parts.size < 2) {
-            bot.reply(message, "Использование: /adduser @username")
-            return
-        }
-
-        val targetUsername = parts[1].trim().removePrefix("@")
-        if (targetUsername.isBlank()) {
-            bot.reply(message, "Использование: /adduser @username")
-            return
-        }
-
-        if (targetUsername == properties.owner) {
-            bot.reply(message, "Владелец не может быть добавлен как пользователь.")
-            return
-        }
-
-        val existing = userService.findByUsername(targetUsername)
-        if (existing != null) {
-            val statusText = if (existing.status == UserStatus.ACTIVE) "активен" else "приглашён"
-            bot.reply(message, "Пользователь @$targetUsername уже $statusText.")
-            return
-        }
-
-        userService.inviteUser(targetUsername)
-        bot.reply(message, "Пользователь @$targetUsername приглашён. Он должен написать /start боту для активации.")
-    }
-
-    private suspend fun handleRemoveUser(message: CommonMessage<TextContent>) {
-        if (!authorizationFilter.isOwner(message)) {
-            bot.reply(message, "Эта команда доступна только владельцу.")
-            return
-        }
-
-        val text = message.content.text
-        val parts = text.split(" ", limit = 2)
-        if (parts.size < 2) {
-            bot.reply(message, "Использование: /removeuser @username")
-            return
-        }
-
-        val targetUsername = parts[1].trim().removePrefix("@")
-        if (targetUsername.isBlank()) {
-            bot.reply(message, "Использование: /removeuser @username")
-            return
-        }
-
-        if (targetUsername == properties.owner) {
-            bot.reply(message, "Владелец не может быть удалён.")
-            return
-        }
-
-        val removed = userService.removeUser(targetUsername)
-        if (removed) {
-            bot.reply(message, "Пользователь @$targetUsername удалён.")
-        } else {
-            bot.reply(message, "Пользователь @$targetUsername не найден.")
-        }
-    }
-
-    private suspend fun handleUsers(message: CommonMessage<TextContent>) {
-        if (!authorizationFilter.isOwner(message)) {
-            bot.reply(message, "Эта команда доступна только владельцу.")
-            return
-        }
-
-        val users = userService.getAllUsers()
-        if (users.isEmpty()) {
-            bot.reply(message, "Нет зарегистрированных пользователей.")
-            return
-        }
-
-        val text =
-            buildString {
-                appendLine("👥 Пользователи:")
-                appendLine()
-                users.forEach { user ->
-                    val statusEmoji = if (user.status == UserStatus.ACTIVE) "✅" else "⏳"
-                    val statusText = if (user.status == UserStatus.ACTIVE) "активен" else "приглашён"
-                    appendLine("$statusEmoji @${user.username} - $statusText")
-                }
-            }
-
-        bot.reply(message, text)
-    }
-
-    private suspend fun handleVersion(message: CommonMessage<TextContent>) {
-        val role = authorizationFilter.getRole(message)
-        if (role == null) {
-            bot.reply(message, authorizationFilter.getUnauthorizedMessage())
-            return
-        }
-
-        val git = gitProperties.ifAvailable
-        val build = buildProperties.ifAvailable
-
-        val text =
-            buildString {
-                if (git != null) {
-                    appendLine("Git version: ${git.commitId}")
-                    appendLine("Git commit time: ${git.commitTime}")
-                } else {
-                    appendLine("Git info not available")
-                }
-                if (build != null) {
-                    appendLine("Build version: ${build.version}")
-                    appendLine("Build time: ${build.time}")
-                } else {
-                    appendLine("Build info not available")
-                }
-            }.trimEnd()
-
-        bot.reply(message, text)
-    }
-
-    @Suppress("LongMethod")
-    private suspend fun BehaviourContext.handleTimezone(message: CommonMessage<TextContent>) {
-        val role = authorizationFilter.getRole(message)
-        if (role == null) {
-            bot.reply(message, authorizationFilter.getUnauthorizedMessage())
-            return
-        }
-
-        val chatId = message.chat.id
-        val currentZone = userService.getUserZone(chatId.chatId.long)
-
-        val tzKeyboard =
-            InlineKeyboardMarkup(
-                keyboard =
-                    matrix {
-                        row {
-                            +CallbackDataInlineKeyboardButton("Калининград (UTC+2)", "tz:Europe/Kaliningrad")
-                            +CallbackDataInlineKeyboardButton("Москва (UTC+3)", "tz:Europe/Moscow")
+                        if (resolvedRole == null) {
+                            reply(message, authorizationFilter.getUnauthorizedMessage())
+                            return@onCommand
                         }
-                        row {
-                            +CallbackDataInlineKeyboardButton("Екатеринбург (UTC+5)", "tz:Asia/Yekaterinburg")
-                            +CallbackDataInlineKeyboardButton("Омск (UTC+6)", "tz:Asia/Omsk")
-                        }
-                        row {
-                            +CallbackDataInlineKeyboardButton("Красноярск (UTC+7)", "tz:Asia/Krasnoyarsk")
-                            +CallbackDataInlineKeyboardButton("Иркутск (UTC+8)", "tz:Asia/Irkutsk")
-                        }
-                        row {
-                            +CallbackDataInlineKeyboardButton("Якутск (UTC+9)", "tz:Asia/Yakutsk")
-                            +CallbackDataInlineKeyboardButton("Владивосток (UTC+10)", "tz:Asia/Vladivostok")
-                        }
-                        row {
-                            +CallbackDataInlineKeyboardButton("Ввести вручную", "tz:manual")
-                            +CallbackDataInlineKeyboardButton("Отмена", "tz:cancel")
-                        }
-                    },
-            )
 
-        val tzSentMessage =
-            sendTextMessage(chatId, "Ваш текущий часовой пояс: $currentZone\nВыберите часовой пояс:", replyMarkup = tzKeyboard)
+                        if (handler.requiredRole == UserRole.OWNER && resolvedRole != UserRole.OWNER) {
+                            reply(message, "Эта команда доступна только владельцу.")
+                            return@onCommand
+                        }
 
-        val callback =
-            waitDataCallbackQuery()
-                .filter {
-                    it.data.startsWith("tz:") &&
-                        (it as? MessageDataCallbackQuery)?.message?.let { msg ->
-                            msg.messageId == tzSentMessage.messageId && msg.chat.id == chatId
-                        } == true
-                }.first()
-        answer(callback)
-
-        when {
-            callback.data == "tz:cancel" -> {
-                sendTextMessage(chatId, "Отменено.")
-            }
-
-            callback.data == "tz:manual" -> {
-                sendTextMessage(chatId, "Введите Olson ID часового пояса (например: Europe/Moscow, Asia/Tokyo):")
-                val inputMsg =
-                    waitTextMessage()
-                        .filter { it.chat.id == chatId }
-                        .first()
-                val input = inputMsg.content.text.trim()
-                if (input == "/cancel") {
-                    sendTextMessage(chatId, "Отменено.")
-                    return
-                }
-                if (!input.contains('/')) {
-                    sendTextMessage(chatId, "Пожалуйста, используйте формат Continent/City (например: Europe/Moscow).")
-                    return
-                }
-                try {
-                    val zone = ZoneId.of(input)
-                    if (!userService.updateTimezone(chatId.chatId.long, zone.id)) {
-                        sendTextMessage(chatId, "Ошибка сохранения часового пояса.")
-                        return
+                        resolvedRole
+                    } else {
+                        null
                     }
-                    val offset = zone.rules.getOffset(Instant.now(clock))
-                    sendTextMessage(chatId, "Часовой пояс сохранён: ${zone.id} (UTC$offset)")
-                } catch (e: DateTimeException) {
-                    sendTextMessage(chatId, "Неизвестный часовой пояс. Попробуйте снова или выберите из списка.")
-                }
-            }
 
-            else -> {
-                val olsonCode = callback.data.removePrefix("tz:")
                 try {
-                    val zone = ZoneId.of(olsonCode)
-                    if (!userService.updateTimezone(chatId.chatId.long, olsonCode)) {
-                        sendTextMessage(chatId, "Ошибка сохранения часового пояса.")
-                        return
+                    with(handler) {
+                        handle(message, role)
                     }
-                    val offset = zone.rules.getOffset(Instant.now(clock))
-                    sendTextMessage(chatId, "Часовой пояс сохранён: $olsonCode (UTC$offset)")
-                } catch (e: DateTimeException) {
-                    sendTextMessage(chatId, "Неизвестный часовой пояс. Попробуйте снова.")
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    logger.error(e) { "Error handling command /${handler.command}" }
+                    reply(message, "Произошла ошибка. Попробуйте позже.")
                 }
             }
+        }
+
+        onContentMessage { message ->
+            val role = authorizationFilter.getRole(message)
+            if (role == null) {
+                reply(message, authorizationFilter.getUnauthorizedMessage())
+                return@onContentMessage
+            }
+            // Ignore non-command messages for now
         }
     }
 
-    @Suppress("LongMethod")
-    private suspend fun BehaviourContext.handleExport(message: CommonMessage<TextContent>) {
-        val role = authorizationFilter.getRole(message)
-        if (role == null) {
-            bot.reply(message, authorizationFilter.getUnauthorizedMessage())
-            return
-        }
-
-        val chatId = message.chat.id
-
-        if (!activeExports.add(chatId.chatId.long)) {
-            bot.reply(message, "Экспорт уже выполняется. Дождитесь завершения текущего экспорта.")
-            return
-        }
-
-        val userZone = userService.getUserZone(chatId.chatId.long)
-        var userNotified = false
-
-        val dialogResult =
-            try {
-                runExportDialog(chatId, userZone) { userNotified = true }
-            } catch (e: Exception) {
-                activeExports.remove(chatId.chatId.long)
-                throw e
-            }
-
-        if (dialogResult == null) {
-            activeExports.remove(chatId.chatId.long)
-            if (!userNotified) {
-                sendTextMessage(chatId, "Время ожидания истекло. Попробуйте снова /export.")
-            }
-            return
-        }
-
-        // Launch export asynchronously so the command handler returns immediately
-        // and the next /export can be processed (rejected by activeExports guard)
+    @EventListener
+    fun onOwnerActivated(event: OwnerActivatedEvent) {
         botScope.launch {
-            try {
-                performExport(chatId, userZone, dialogResult)
-            } finally {
-                activeExports.remove(chatId.chatId.long)
-            }
-        }
-    }
-
-    @Suppress("LongMethod")
-    private suspend fun BehaviourContext.runExportDialog(
-        chatId: IdChatIdentifier,
-        userZone: ZoneId,
-        onUserNotified: () -> Unit,
-    ): ExportDialogResult? =
-        withTimeoutOrNull(EXPORT_DIALOG_TIMEOUT_MS) {
-            // Step 1: Date selection
-            val dateKeyboard =
-                InlineKeyboardMarkup(
-                    keyboard =
-                        matrix {
-                            row {
-                                +CallbackDataInlineKeyboardButton("Сегодня", "export:today")
-                                +CallbackDataInlineKeyboardButton("Вчера", "export:yesterday")
-                            }
-                            row {
-                                +CallbackDataInlineKeyboardButton("Ввести дату", "export:custom")
-                                +CallbackDataInlineKeyboardButton("Отмена", "export:cancel")
-                            }
-                        },
-                )
-
-            val dateSentMessage = sendTextMessage(chatId, "Выберите дату:", replyMarkup = dateKeyboard)
-
-            val dateCallback =
-                waitDataCallbackQuery()
-                    .filter {
-                        it.data.startsWith("export:") &&
-                            (it as? MessageDataCallbackQuery)?.message?.let { msg ->
-                                msg.messageId == dateSentMessage.messageId && msg.chat.id == chatId
-                            } == true
-                    }.first()
-            answer(dateCallback)
-            try {
-                editMessageReplyMarkup(dateSentMessage, replyMarkup = null)
-            } catch (_: Exception) {
-            }
-
-            if (dateCallback.data == "export:cancel") {
-                sendTextMessage(chatId, "Экспорт отменён.")
-                onUserNotified()
-                return@withTimeoutOrNull null
-            }
-
-            val date: LocalDate =
-                when (dateCallback.data) {
-                    "export:today" -> {
-                        Instant.now(clock).atZone(userZone).toLocalDate()
-                    }
-
-                    "export:yesterday" -> {
-                        Instant
-                            .now(clock)
-                            .atZone(userZone)
-                            .toLocalDate()
-                            .minusDays(1)
-                    }
-
-                    "export:custom" -> {
-                        sendTextMessage(chatId, "Введите дату (формат: YYYY-MM-DD) или /cancel для отмены:")
-                        val dateMsg =
-                            waitTextMessage()
-                                .filter { it.chat.id == chatId }
-                                .first()
-                        val dateInput = dateMsg.content.text.trim()
-                        if (dateInput == "/cancel" || dateInput.equals("отмена", ignoreCase = true)) {
-                            sendTextMessage(chatId, "Экспорт отменён.")
-                            onUserNotified()
-                            return@withTimeoutOrNull null
-                        }
-                        try {
-                            LocalDate.parse(dateInput)
-                        } catch (e: DateTimeParseException) {
-                            sendTextMessage(chatId, "Неверный формат даты. Используйте YYYY-MM-DD. Экспорт отменён.")
-                            onUserNotified()
-                            return@withTimeoutOrNull null
-                        }
-                    }
-
-                    else -> {
-                        return@withTimeoutOrNull null
-                    }
-                }
-
-            // Step 2: Time range input
-            sendTextMessage(
-                chatId,
-                "Введите диапазон времени (например: 9:15-9:20, макс. 5 минут)\nВремя в вашем часовом поясе: $userZone\nИли /cancel:",
-            )
-            val timeMsg =
-                waitTextMessage()
-                    .filter { it.chat.id == chatId }
-                    .first()
-
-            val timeInput = timeMsg.content.text.trim()
-            if (timeInput == "/cancel" || timeInput.equals("отмена", ignoreCase = true)) {
-                sendTextMessage(chatId, "Экспорт отменён.")
-                onUserNotified()
-                return@withTimeoutOrNull null
-            }
-
-            val timeRange = parseTimeRange(timeInput)
-            if (timeRange == null) {
-                sendTextMessage(chatId, "Неверный формат. Используйте H:MM-H:MM (например, 9:15-9:20). Экспорт отменён.")
-                onUserNotified()
-                return@withTimeoutOrNull null
-            }
-
-            val (startTime, endTime) = timeRange
-            val durationMinutes = ChronoUnit.MINUTES.between(startTime, endTime)
-            if (durationMinutes > MAX_EXPORT_DURATION_MINUTES || durationMinutes <= 0) {
-                sendTextMessage(
-                    chatId,
-                    "Диапазон должен быть от 1 до $MAX_EXPORT_DURATION_MINUTES минут. Экспорт отменён.",
-                )
-                onUserNotified()
-                return@withTimeoutOrNull null
-            }
-
-            // Convert to Instant using user's timezone
-            val startInstant = LocalDateTime.of(date, startTime).atZone(userZone).toInstant()
-            val endInstant = LocalDateTime.of(date, endTime).atZone(userZone).toInstant()
-
-            // DST guard: validate duration after timezone conversion
-            val actualDuration = Duration.between(startInstant, endInstant)
-            if (actualDuration.isNegative || actualDuration.isZero || actualDuration.toMinutes() > MAX_EXPORT_DURATION_MINUTES) {
-                sendTextMessage(
-                    chatId,
-                    "Диапазон после конвертации в UTC превышает 5 минут " +
-                        "(возможно из-за перехода на летнее/зимнее время). Попробуйте другой диапазон.",
-                )
-                onUserNotified()
-                return@withTimeoutOrNull null
-            }
-
-            // Step 3: Camera selection
-            val cameras = videoExportService.findCamerasWithRecordings(startInstant, endInstant)
-            if (cameras.isEmpty()) {
-                sendTextMessage(chatId, "Записей за $date $startTime-$endTime не найдено.")
-                onUserNotified()
-                return@withTimeoutOrNull null
-            }
-
-            val cameraKeyboard =
-                InlineKeyboardMarkup(
-                    keyboard =
-                        matrix {
-                            cameras.forEach { cam ->
-                                row {
-                                    +CallbackDataInlineKeyboardButton(
-                                        "${cam.camId} (${cam.recordingsCount})",
-                                        "export:cam:${cam.camId}",
-                                    )
-                                }
-                            }
-                            row {
-                                +CallbackDataInlineKeyboardButton("Отмена", "export:cancel")
-                            }
-                        },
-                )
-
-            val camSentMessage = sendTextMessage(chatId, "Выберите камеру:", replyMarkup = cameraKeyboard)
-
-            val camCallback =
-                waitDataCallbackQuery()
-                    .filter {
-                        (it.data.startsWith("export:cam:") || it.data == "export:cancel") &&
-                            (it as? MessageDataCallbackQuery)?.message?.let { msg ->
-                                msg.messageId == camSentMessage.messageId && msg.chat.id == chatId
-                            } == true
-                    }.first()
-            answer(camCallback)
-            try {
-                editMessageReplyMarkup(camSentMessage, replyMarkup = null)
-            } catch (_: Exception) {
-            }
-
-            if (camCallback.data == "export:cancel") {
-                sendTextMessage(chatId, "Экспорт отменён.")
-                onUserNotified()
-                return@withTimeoutOrNull null
-            }
-
-            val camId = camCallback.data.removePrefix("export:cam:")
-
-            // Step 4: Mode selection
-            val modeKeyboard =
-                InlineKeyboardMarkup(
-                    keyboard =
-                        matrix {
-                            row {
-                                +CallbackDataInlineKeyboardButton("Оригинал", "export:mode:original")
-                                +CallbackDataInlineKeyboardButton("С объектами", "export:mode:annotated")
-                            }
-                            row {
-                                +CallbackDataInlineKeyboardButton("Отмена", "export:cancel")
-                            }
-                        },
-                )
-
-            val modeSentMessage = sendTextMessage(chatId, "Выберите режим экспорта:", replyMarkup = modeKeyboard)
-
-            val modeCallback =
-                waitDataCallbackQuery()
-                    .filter {
-                        (it.data.startsWith("export:mode:") || it.data == "export:cancel") &&
-                            (it as? MessageDataCallbackQuery)?.message?.let { msg ->
-                                msg.messageId == modeSentMessage.messageId && msg.chat.id == chatId
-                            } == true
-                    }.first()
-            answer(modeCallback)
-            try {
-                editMessageReplyMarkup(modeSentMessage, replyMarkup = null)
-            } catch (_: Exception) {
-            }
-
-            if (modeCallback.data == "export:cancel") {
-                sendTextMessage(chatId, "Экспорт отменён.")
-                onUserNotified()
-                return@withTimeoutOrNull null
-            }
-
-            val mode =
-                when (modeCallback.data) {
-                    "export:mode:annotated" -> ExportMode.ANNOTATED
-                    else -> ExportMode.ORIGINAL
-                }
-
-            ExportDialogResult(startInstant, endInstant, camId, mode)
-        }
-
-    @Suppress("LongMethod")
-    private suspend fun performExport(
-        chatId: IdChatIdentifier,
-        userZone: ZoneId,
-        dialogResult: ExportDialogResult,
-    ) {
-        val (startInstant, endInstant, camId, mode) = dialogResult
-
-        val statusMessage = bot.sendTextMessage(chatId, renderProgress(Stage.PREPARING, mode = mode))
-
-        var lastRenderedStage: Stage? = Stage.PREPARING
-        var lastRenderedPercent: Int? = null
-        var hadCompressing = false
-
-        val onProgress: suspend (VideoExportProgress) -> Unit = { progress ->
-            if (progress.stage == Stage.COMPRESSING) hadCompressing = true
-
-            val shouldUpdate =
-                when {
-                    progress.stage != lastRenderedStage -> {
-                        true
-                    }
-
-                    progress.stage == Stage.ANNOTATING && progress.percent != null -> {
-                        val lastPct = lastRenderedPercent ?: -1
-                        (progress.percent - lastPct) >= 5
-                    }
-
-                    else -> {
-                        false
-                    }
-                }
-
-            if (shouldUpdate) {
-                lastRenderedStage = progress.stage
-                lastRenderedPercent = progress.percent
-                try {
-                    bot.editMessageText(
-                        statusMessage,
-                        renderProgress(progress.stage, progress.percent, mode, hadCompressing),
-                    )
-                } catch (e: Exception) {
-                    logger.warn(e) { "Failed to update export progress message" }
-                }
-            }
-        }
-
-        try {
-            val processingTimeout =
-                if (mode == ExportMode.ANNOTATED) EXPORT_ANNOTATED_TIMEOUT_MS else EXPORT_ORIGINAL_TIMEOUT_MS
-            val videoPath =
-                withTimeoutOrNull(processingTimeout) {
-                    videoExportService.exportVideo(startInstant, endInstant, camId, mode, onProgress)
-                } ?: run {
-                    bot.sendTextMessage(chatId, "Обработка видео заняла слишком много времени. Попробуйте меньший диапазон.")
-                    return
-                }
-
-            try {
-                try {
-                    bot.editMessageText(statusMessage, renderProgress(Stage.SENDING, mode = mode, compressing = hadCompressing))
-                } catch (e: Exception) {
-                    logger.warn(e) { "Failed to update export progress message" }
-                }
-
-                val localDate = startInstant.atZone(userZone).toLocalDate()
-                val localStart = startInstant.atZone(userZone).toLocalTime()
-                val localEnd = endInstant.atZone(userZone).toLocalTime()
-                val fileName = "export_${camId}_${localDate}_$localStart-$localEnd.mp4".replace(":", "-")
-                val sent =
-                    withTimeoutOrNull(properties.sendVideoTimeout.toMillis()) {
-                        bot.sendVideo(
-                            chatId,
-                            videoPath.toFile().asMultipartFile().copy(filename = fileName),
-                        )
-                    }
-
-                if (sent == null) {
-                    logger.error {
-                        "Telegram sendVideo timed out after ${properties.sendVideoTimeout} " +
-                            "for chat=$chatId, camera=$camId, file=$fileName"
-                    }
-                    bot.sendTextMessage(
-                        chatId,
-                        "Не удалось отправить видео: превышено время ожидания " +
-                            "(${properties.sendVideoTimeout.toSeconds()} сек). " +
-                            "Возможно, проблемы с сетью. Попробуйте позже.",
-                    )
-                    return
-                }
-
-                try {
-                    bot.editMessageText(statusMessage, renderProgress(Stage.DONE, mode = mode, compressing = hadCompressing))
-                } catch (e: Exception) {
-                    logger.warn(e) { "Failed to update export progress message" }
-                }
-            } finally {
-                try {
-                    videoExportService.cleanupExportFile(videoPath)
-                } catch (e: Exception) {
-                    logger.warn(e) { "Failed to delete temp file: $videoPath" }
-                }
-            }
-        } catch (e: Exception) {
-            logger.error(e) { "Video export failed" }
-            val errorText =
-                if (mode == ExportMode.ANNOTATED) {
-                    "Ошибка экспорта видео с объектами. Попробуйте обычный режим или другие параметры."
-                } else {
-                    "Ошибка экспорта видео. Попробуйте меньший диапазон или другую камеру."
-                }
-            bot.sendTextMessage(chatId, errorText)
-        }
-    }
-
-    private fun parseTimeRange(input: String): Pair<LocalTime, LocalTime>? {
-        val parts = input.split("-", limit = 2)
-        if (parts.size != 2) return null
-        return try {
-            val formatter = DateTimeFormatter.ofPattern("H:mm")
-            val start = LocalTime.parse(parts[0].trim(), formatter)
-            val end = LocalTime.parse(parts[1].trim(), formatter)
-            start to end
-        } catch (e: DateTimeParseException) {
-            null
+            registerOwnerCommands(event.chatId)
         }
     }
 
     private suspend fun registerDefaultCommands() {
         try {
-            bot.setMyCommands(DEFAULT_COMMANDS, scope = BotCommandScopeDefault)
+            bot.setMyCommands(defaultCommands, scope = BotCommandScopeDefault)
             logger.info { "Default bot commands registered" }
         } catch (e: Exception) {
             logger.warn(e) { "Failed to register default bot commands" }
@@ -951,7 +152,7 @@ class FrigateAnalyzerBot(
 
     private suspend fun registerOwnerCommands(chatId: Long) {
         try {
-            bot.setMyCommands(OWNER_COMMANDS, scope = BotCommandScopeChat(ChatId(RawChatId(chatId))))
+            bot.setMyCommands(ownerCommands, scope = BotCommandScopeChat(ChatId(RawChatId(chatId))))
             logger.info { "Owner bot commands registered for chat $chatId" }
         } catch (e: Exception) {
             logger.warn(e) { "Failed to register owner bot commands for chat $chatId" }

--- a/modules/telegram/src/main/kotlin/ru/zinin/frigate/analyzer/telegram/bot/handler/AddUserCommandHandler.kt
+++ b/modules/telegram/src/main/kotlin/ru/zinin/frigate/analyzer/telegram/bot/handler/AddUserCommandHandler.kt
@@ -1,0 +1,58 @@
+package ru.zinin.frigate.analyzer.telegram.bot.handler
+
+import dev.inmo.tgbotapi.extensions.api.send.reply
+import dev.inmo.tgbotapi.extensions.behaviour_builder.BehaviourContext
+import dev.inmo.tgbotapi.types.message.abstracts.CommonMessage
+import dev.inmo.tgbotapi.types.message.content.TextContent
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+import ru.zinin.frigate.analyzer.telegram.config.TelegramProperties
+import ru.zinin.frigate.analyzer.telegram.model.UserRole
+import ru.zinin.frigate.analyzer.telegram.model.UserStatus
+import ru.zinin.frigate.analyzer.telegram.service.TelegramUserService
+
+@Component
+@ConditionalOnProperty(prefix = "application.telegram", name = ["enabled"], havingValue = "true")
+class AddUserCommandHandler(
+    private val userService: TelegramUserService,
+    private val properties: TelegramProperties,
+) : CommandHandler {
+    override val command: String = "adduser"
+    override val description: String = "Добавить пользователя"
+    override val requiredRole: UserRole = UserRole.OWNER
+    override val ownerOnly: Boolean = true
+    override val order: Int = 10
+
+    override suspend fun BehaviourContext.handle(
+        message: CommonMessage<TextContent>,
+        role: UserRole?,
+    ) {
+        val text = message.content.text
+        val parts = text.split(" ", limit = 2)
+        if (parts.size < 2) {
+            reply(message, "Использование: /adduser @username")
+            return
+        }
+
+        val targetUsername = parts[1].trim().removePrefix("@")
+        if (targetUsername.isBlank()) {
+            reply(message, "Использование: /adduser @username")
+            return
+        }
+
+        if (targetUsername == properties.owner) {
+            reply(message, "Владелец не может быть добавлен как пользователь.")
+            return
+        }
+
+        val existing = userService.findByUsername(targetUsername)
+        if (existing != null) {
+            val statusText = if (existing.status == UserStatus.ACTIVE) "активен" else "приглашён"
+            reply(message, "Пользователь @$targetUsername уже $statusText.")
+            return
+        }
+
+        userService.inviteUser(targetUsername)
+        reply(message, "Пользователь @$targetUsername приглашён. Он должен написать /start боту для активации.")
+    }
+}

--- a/modules/telegram/src/main/kotlin/ru/zinin/frigate/analyzer/telegram/bot/handler/CommandHandler.kt
+++ b/modules/telegram/src/main/kotlin/ru/zinin/frigate/analyzer/telegram/bot/handler/CommandHandler.kt
@@ -1,0 +1,23 @@
+package ru.zinin.frigate.analyzer.telegram.bot.handler
+
+import dev.inmo.tgbotapi.extensions.behaviour_builder.BehaviourContext
+import dev.inmo.tgbotapi.types.message.abstracts.CommonMessage
+import dev.inmo.tgbotapi.types.message.content.TextContent
+import ru.zinin.frigate.analyzer.telegram.model.UserRole
+
+interface CommandHandler {
+    val command: String
+
+    val description: String
+
+    val requiredRole: UserRole?
+
+    val ownerOnly: Boolean get() = false
+
+    val order: Int
+
+    suspend fun BehaviourContext.handle(
+        message: CommonMessage<TextContent>,
+        role: UserRole?,
+    )
+}

--- a/modules/telegram/src/main/kotlin/ru/zinin/frigate/analyzer/telegram/bot/handler/HelpCommandHandler.kt
+++ b/modules/telegram/src/main/kotlin/ru/zinin/frigate/analyzer/telegram/bot/handler/HelpCommandHandler.kt
@@ -1,0 +1,50 @@
+package ru.zinin.frigate.analyzer.telegram.bot.handler
+
+import dev.inmo.tgbotapi.extensions.api.send.reply
+import dev.inmo.tgbotapi.extensions.behaviour_builder.BehaviourContext
+import dev.inmo.tgbotapi.types.message.abstracts.CommonMessage
+import dev.inmo.tgbotapi.types.message.content.TextContent
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Lazy
+import org.springframework.stereotype.Component
+import ru.zinin.frigate.analyzer.telegram.model.UserRole
+
+@Component
+@ConditionalOnProperty(prefix = "application.telegram", name = ["enabled"], havingValue = "true")
+class HelpCommandHandler(
+    @Lazy private val handlers: List<CommandHandler>,
+) : CommandHandler {
+    override val command: String = "help"
+    override val description: String = "Помощь"
+    override val requiredRole: UserRole = UserRole.USER
+    override val order: Int = 2
+
+    override suspend fun BehaviourContext.handle(
+        message: CommonMessage<TextContent>,
+        role: UserRole?,
+    ) {
+        val sortedHandlers = handlers.sortedWith(compareBy<CommandHandler> { it.order }.thenBy { it.command })
+        val defaultCommands = sortedHandlers.filterNot { it.ownerOnly }
+        val ownerCommands = sortedHandlers.filter { it.ownerOnly }
+
+        val helpText =
+            buildString {
+                appendLine("📋 Доступные команды:")
+                appendLine()
+
+                defaultCommands.forEach { handler ->
+                    appendLine("/${handler.command} - ${handler.description}")
+                }
+
+                if (role == UserRole.OWNER && ownerCommands.isNotEmpty()) {
+                    appendLine()
+                    appendLine("👑 Команды владельца:")
+                    ownerCommands.forEach { handler ->
+                        appendLine("/${handler.command} - ${handler.description}")
+                    }
+                }
+            }
+
+        reply(message, helpText)
+    }
+}

--- a/modules/telegram/src/main/kotlin/ru/zinin/frigate/analyzer/telegram/bot/handler/OwnerActivatedEvent.kt
+++ b/modules/telegram/src/main/kotlin/ru/zinin/frigate/analyzer/telegram/bot/handler/OwnerActivatedEvent.kt
@@ -1,0 +1,5 @@
+package ru.zinin.frigate.analyzer.telegram.bot.handler
+
+data class OwnerActivatedEvent(
+    val chatId: Long,
+)

--- a/modules/telegram/src/main/kotlin/ru/zinin/frigate/analyzer/telegram/bot/handler/RemoveUserCommandHandler.kt
+++ b/modules/telegram/src/main/kotlin/ru/zinin/frigate/analyzer/telegram/bot/handler/RemoveUserCommandHandler.kt
@@ -1,0 +1,54 @@
+package ru.zinin.frigate.analyzer.telegram.bot.handler
+
+import dev.inmo.tgbotapi.extensions.api.send.reply
+import dev.inmo.tgbotapi.extensions.behaviour_builder.BehaviourContext
+import dev.inmo.tgbotapi.types.message.abstracts.CommonMessage
+import dev.inmo.tgbotapi.types.message.content.TextContent
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+import ru.zinin.frigate.analyzer.telegram.config.TelegramProperties
+import ru.zinin.frigate.analyzer.telegram.model.UserRole
+import ru.zinin.frigate.analyzer.telegram.service.TelegramUserService
+
+@Component
+@ConditionalOnProperty(prefix = "application.telegram", name = ["enabled"], havingValue = "true")
+class RemoveUserCommandHandler(
+    private val userService: TelegramUserService,
+    private val properties: TelegramProperties,
+) : CommandHandler {
+    override val command: String = "removeuser"
+    override val description: String = "Удалить пользователя"
+    override val requiredRole: UserRole = UserRole.OWNER
+    override val ownerOnly: Boolean = true
+    override val order: Int = 11
+
+    override suspend fun BehaviourContext.handle(
+        message: CommonMessage<TextContent>,
+        role: UserRole?,
+    ) {
+        val text = message.content.text
+        val parts = text.split(" ", limit = 2)
+        if (parts.size < 2) {
+            reply(message, "Использование: /removeuser @username")
+            return
+        }
+
+        val targetUsername = parts[1].trim().removePrefix("@")
+        if (targetUsername.isBlank()) {
+            reply(message, "Использование: /removeuser @username")
+            return
+        }
+
+        if (targetUsername == properties.owner) {
+            reply(message, "Владелец не может быть удалён.")
+            return
+        }
+
+        val removed = userService.removeUser(targetUsername)
+        if (removed) {
+            reply(message, "Пользователь @$targetUsername удалён.")
+        } else {
+            reply(message, "Пользователь @$targetUsername не найден.")
+        }
+    }
+}

--- a/modules/telegram/src/main/kotlin/ru/zinin/frigate/analyzer/telegram/bot/handler/StartCommandHandler.kt
+++ b/modules/telegram/src/main/kotlin/ru/zinin/frigate/analyzer/telegram/bot/handler/StartCommandHandler.kt
@@ -1,0 +1,93 @@
+package ru.zinin.frigate.analyzer.telegram.bot.handler
+
+import dev.inmo.tgbotapi.extensions.api.send.reply
+import dev.inmo.tgbotapi.extensions.behaviour_builder.BehaviourContext
+import dev.inmo.tgbotapi.types.message.abstracts.CommonMessage
+import dev.inmo.tgbotapi.types.message.abstracts.PrivateContentMessage
+import dev.inmo.tgbotapi.types.message.content.TextContent
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+import ru.zinin.frigate.analyzer.telegram.config.TelegramProperties
+import ru.zinin.frigate.analyzer.telegram.model.UserRole
+import ru.zinin.frigate.analyzer.telegram.model.UserStatus
+import ru.zinin.frigate.analyzer.telegram.service.TelegramUserService
+
+@Component
+@ConditionalOnProperty(prefix = "application.telegram", name = ["enabled"], havingValue = "true")
+class StartCommandHandler(
+    private val userService: TelegramUserService,
+    private val properties: TelegramProperties,
+    private val eventPublisher: ApplicationEventPublisher,
+) : CommandHandler {
+    override val command: String = "start"
+    override val description: String = "Начать работу с ботом"
+    override val requiredRole: UserRole? = null
+    override val order: Int = 1
+
+    override suspend fun BehaviourContext.handle(
+        message: CommonMessage<TextContent>,
+        role: UserRole?,
+    ) {
+        val privateMessage = message as? PrivateContentMessage<*>
+        val username = privateMessage?.user?.username?.withoutAt
+        if (username == null) {
+            reply(message, "Ошибка: не удалось определить ваш username.")
+            return
+        }
+
+        val chatId = message.chat.id.chatId.long
+        val userId =
+            privateMessage
+                .user
+                .id
+                .chatId
+                .long
+
+        if (username == properties.owner) {
+            val existing = userService.findByUsername(username)
+            if (existing == null) {
+                userService.inviteUser(username)
+            }
+            if (existing?.status != UserStatus.ACTIVE) {
+                userService.activateUser(
+                    username = username,
+                    chatId = chatId,
+                    userId = userId,
+                    firstName = privateMessage.user.firstName,
+                    lastName = privateMessage.user.lastName,
+                )
+            }
+
+            reply(message, "Добро пожаловать, владелец! Используйте /help для списка команд.")
+            eventPublisher.publishEvent(OwnerActivatedEvent(chatId))
+            return
+        }
+
+        val user = userService.findByUsername(username)
+        if (user == null) {
+            reply(message, properties.unauthorizedMessage)
+            return
+        }
+
+        if (user.status == UserStatus.ACTIVE) {
+            reply(message, "Вы уже подписаны на уведомления. Используйте /help для списка команд.")
+            return
+        }
+
+        val activated =
+            userService.activateUser(
+                username = username,
+                chatId = chatId,
+                userId = userId,
+                firstName = privateMessage.user.firstName,
+                lastName = privateMessage.user.lastName,
+            )
+
+        if (activated != null) {
+            reply(message, "Вы успешно подписались на уведомления! Используйте /help для списка команд.")
+        } else {
+            reply(message, "Ошибка активации. Обратитесь к администратору.")
+        }
+    }
+}

--- a/modules/telegram/src/main/kotlin/ru/zinin/frigate/analyzer/telegram/bot/handler/TimezoneCommandHandler.kt
+++ b/modules/telegram/src/main/kotlin/ru/zinin/frigate/analyzer/telegram/bot/handler/TimezoneCommandHandler.kt
@@ -1,0 +1,151 @@
+package ru.zinin.frigate.analyzer.telegram.bot.handler
+
+import dev.inmo.tgbotapi.extensions.api.answers.answer
+import dev.inmo.tgbotapi.extensions.api.send.sendTextMessage
+import dev.inmo.tgbotapi.extensions.behaviour_builder.BehaviourContext
+import dev.inmo.tgbotapi.extensions.behaviour_builder.expectations.waitDataCallbackQuery
+import dev.inmo.tgbotapi.extensions.behaviour_builder.expectations.waitTextMessage
+import dev.inmo.tgbotapi.types.buttons.InlineKeyboardButtons.CallbackDataInlineKeyboardButton
+import dev.inmo.tgbotapi.types.buttons.InlineKeyboardMarkup
+import dev.inmo.tgbotapi.types.message.abstracts.CommonMessage
+import dev.inmo.tgbotapi.types.message.content.TextContent
+import dev.inmo.tgbotapi.types.queries.callback.MessageDataCallbackQuery
+import dev.inmo.tgbotapi.utils.matrix
+import dev.inmo.tgbotapi.utils.row
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+import ru.zinin.frigate.analyzer.telegram.model.UserRole
+import ru.zinin.frigate.analyzer.telegram.service.TelegramUserService
+import java.time.Clock
+import java.time.DateTimeException
+import java.time.Instant
+import java.time.ZoneId
+
+@Component
+@ConditionalOnProperty(prefix = "application.telegram", name = ["enabled"], havingValue = "true")
+class TimezoneCommandHandler(
+    private val userService: TelegramUserService,
+    private val clock: Clock,
+) : CommandHandler {
+    override val command: String = "timezone"
+    override val description: String = "Часовой пояс"
+    override val requiredRole: UserRole = UserRole.USER
+    override val order: Int = 4
+
+    @Suppress("LongMethod")
+    override suspend fun BehaviourContext.handle(
+        message: CommonMessage<TextContent>,
+        role: UserRole?,
+    ) {
+        val chatId = message.chat.id
+        val currentZone = userService.getUserZone(chatId.chatId.long)
+
+        val completed =
+            withTimeoutOrNull(TIMEZONE_DIALOG_TIMEOUT_MS) {
+                val tzKeyboard =
+                    InlineKeyboardMarkup(
+                        keyboard =
+                            matrix {
+                                row {
+                                    +CallbackDataInlineKeyboardButton("Калининград (UTC+2)", "tz:Europe/Kaliningrad")
+                                    +CallbackDataInlineKeyboardButton("Москва (UTC+3)", "tz:Europe/Moscow")
+                                }
+                                row {
+                                    +CallbackDataInlineKeyboardButton("Екатеринбург (UTC+5)", "tz:Asia/Yekaterinburg")
+                                    +CallbackDataInlineKeyboardButton("Омск (UTC+6)", "tz:Asia/Omsk")
+                                }
+                                row {
+                                    +CallbackDataInlineKeyboardButton("Красноярск (UTC+7)", "tz:Asia/Krasnoyarsk")
+                                    +CallbackDataInlineKeyboardButton("Иркутск (UTC+8)", "tz:Asia/Irkutsk")
+                                }
+                                row {
+                                    +CallbackDataInlineKeyboardButton("Якутск (UTC+9)", "tz:Asia/Yakutsk")
+                                    +CallbackDataInlineKeyboardButton("Владивосток (UTC+10)", "tz:Asia/Vladivostok")
+                                }
+                                row {
+                                    +CallbackDataInlineKeyboardButton("Ввести вручную", "tz:manual")
+                                    +CallbackDataInlineKeyboardButton("Отмена", "tz:cancel")
+                                }
+                            },
+                    )
+
+                val tzSentMessage =
+                    sendTextMessage(chatId, "Ваш текущий часовой пояс: $currentZone\nВыберите часовой пояс:", replyMarkup = tzKeyboard)
+
+                val callback =
+                    waitDataCallbackQuery()
+                        .filter {
+                            it.data.startsWith("tz:") &&
+                                (it as? MessageDataCallbackQuery)?.message?.let { msg ->
+                                    msg.messageId == tzSentMessage.messageId && msg.chat.id == chatId
+                                } == true
+                        }.first()
+                answer(callback)
+
+                when {
+                    callback.data == "tz:cancel" -> {
+                        sendTextMessage(chatId, "Отменено.")
+                    }
+
+                    callback.data == "tz:manual" -> {
+                        sendTextMessage(chatId, "Введите Olson ID часового пояса (например: Europe/Moscow, Asia/Tokyo):")
+                        val inputMsg =
+                            waitTextMessage()
+                                .filter { it.chat.id == chatId }
+                                .first()
+                        val input = inputMsg.content.text.trim()
+
+                        if (input == "/cancel") {
+                            sendTextMessage(chatId, "Отменено.")
+                            return@withTimeoutOrNull
+                        }
+
+                        if (!input.contains('/')) {
+                            sendTextMessage(chatId, "Пожалуйста, используйте формат Continent/City (например: Europe/Moscow).")
+                            return@withTimeoutOrNull
+                        }
+
+                        try {
+                            val zone = ZoneId.of(input)
+                            if (!userService.updateTimezone(chatId.chatId.long, zone.id)) {
+                                sendTextMessage(chatId, "Ошибка сохранения часового пояса.")
+                                return@withTimeoutOrNull
+                            }
+
+                            val offset = zone.rules.getOffset(Instant.now(clock))
+                            sendTextMessage(chatId, "Часовой пояс сохранён: ${zone.id} (UTC$offset)")
+                        } catch (e: DateTimeException) {
+                            sendTextMessage(chatId, "Неизвестный часовой пояс. Попробуйте снова или выберите из списка.")
+                        }
+                    }
+
+                    else -> {
+                        val olsonCode = callback.data.removePrefix("tz:")
+                        try {
+                            val zone = ZoneId.of(olsonCode)
+                            if (!userService.updateTimezone(chatId.chatId.long, olsonCode)) {
+                                sendTextMessage(chatId, "Ошибка сохранения часового пояса.")
+                                return@withTimeoutOrNull
+                            }
+
+                            val offset = zone.rules.getOffset(Instant.now(clock))
+                            sendTextMessage(chatId, "Часовой пояс сохранён: $olsonCode (UTC$offset)")
+                        } catch (e: DateTimeException) {
+                            sendTextMessage(chatId, "Неизвестный часовой пояс. Попробуйте снова.")
+                        }
+                    }
+                }
+            }
+
+        if (completed == null) {
+            sendTextMessage(chatId, "Время ожидания истекло. Попробуйте снова /timezone.")
+        }
+    }
+
+    companion object {
+        private const val TIMEZONE_DIALOG_TIMEOUT_MS = 120_000L
+    }
+}

--- a/modules/telegram/src/main/kotlin/ru/zinin/frigate/analyzer/telegram/bot/handler/UsersCommandHandler.kt
+++ b/modules/telegram/src/main/kotlin/ru/zinin/frigate/analyzer/telegram/bot/handler/UsersCommandHandler.kt
@@ -1,0 +1,47 @@
+package ru.zinin.frigate.analyzer.telegram.bot.handler
+
+import dev.inmo.tgbotapi.extensions.api.send.reply
+import dev.inmo.tgbotapi.extensions.behaviour_builder.BehaviourContext
+import dev.inmo.tgbotapi.types.message.abstracts.CommonMessage
+import dev.inmo.tgbotapi.types.message.content.TextContent
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+import ru.zinin.frigate.analyzer.telegram.model.UserRole
+import ru.zinin.frigate.analyzer.telegram.model.UserStatus
+import ru.zinin.frigate.analyzer.telegram.service.TelegramUserService
+
+@Component
+@ConditionalOnProperty(prefix = "application.telegram", name = ["enabled"], havingValue = "true")
+class UsersCommandHandler(
+    private val userService: TelegramUserService,
+) : CommandHandler {
+    override val command: String = "users"
+    override val description: String = "Список пользователей"
+    override val requiredRole: UserRole = UserRole.OWNER
+    override val ownerOnly: Boolean = true
+    override val order: Int = 12
+
+    override suspend fun BehaviourContext.handle(
+        message: CommonMessage<TextContent>,
+        role: UserRole?,
+    ) {
+        val users = userService.getAllUsers()
+        if (users.isEmpty()) {
+            reply(message, "Нет зарегистрированных пользователей.")
+            return
+        }
+
+        val text =
+            buildString {
+                appendLine("👥 Пользователи:")
+                appendLine()
+                users.forEach { user ->
+                    val statusEmoji = if (user.status == UserStatus.ACTIVE) "✅" else "⏳"
+                    val statusText = if (user.status == UserStatus.ACTIVE) "активен" else "приглашён"
+                    appendLine("$statusEmoji @${user.username} - $statusText")
+                }
+            }
+
+        reply(message, text)
+    }
+}

--- a/modules/telegram/src/main/kotlin/ru/zinin/frigate/analyzer/telegram/bot/handler/VersionCommandHandler.kt
+++ b/modules/telegram/src/main/kotlin/ru/zinin/frigate/analyzer/telegram/bot/handler/VersionCommandHandler.kt
@@ -1,0 +1,51 @@
+package ru.zinin.frigate.analyzer.telegram.bot.handler
+
+import dev.inmo.tgbotapi.extensions.api.send.reply
+import dev.inmo.tgbotapi.extensions.behaviour_builder.BehaviourContext
+import dev.inmo.tgbotapi.types.message.abstracts.CommonMessage
+import dev.inmo.tgbotapi.types.message.content.TextContent
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.info.BuildProperties
+import org.springframework.boot.info.GitProperties
+import org.springframework.stereotype.Component
+import ru.zinin.frigate.analyzer.telegram.model.UserRole
+
+@Component
+@ConditionalOnProperty(prefix = "application.telegram", name = ["enabled"], havingValue = "true")
+class VersionCommandHandler(
+    private val buildProperties: ObjectProvider<BuildProperties>,
+    private val gitProperties: ObjectProvider<GitProperties>,
+) : CommandHandler {
+    override val command: String = "version"
+    override val description: String = "Версия приложения"
+    override val requiredRole: UserRole = UserRole.USER
+    override val order: Int = 5
+
+    override suspend fun BehaviourContext.handle(
+        message: CommonMessage<TextContent>,
+        role: UserRole?,
+    ) {
+        val git = gitProperties.ifAvailable
+        val build = buildProperties.ifAvailable
+
+        val text =
+            buildString {
+                if (git != null) {
+                    appendLine("Git version: ${git.commitId}")
+                    appendLine("Git commit time: ${git.commitTime}")
+                } else {
+                    appendLine("Git info not available")
+                }
+
+                if (build != null) {
+                    appendLine("Build version: ${build.version}")
+                    appendLine("Build time: ${build.time}")
+                } else {
+                    appendLine("Build info not available")
+                }
+            }.trimEnd()
+
+        reply(message, text)
+    }
+}

--- a/modules/telegram/src/main/kotlin/ru/zinin/frigate/analyzer/telegram/bot/handler/export/ActiveExportTracker.kt
+++ b/modules/telegram/src/main/kotlin/ru/zinin/frigate/analyzer/telegram/bot/handler/export/ActiveExportTracker.kt
@@ -1,0 +1,17 @@
+package ru.zinin.frigate.analyzer.telegram.bot.handler.export
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+import java.util.concurrent.ConcurrentHashMap
+
+@Component
+@ConditionalOnProperty(prefix = "application.telegram", name = ["enabled"], havingValue = "true")
+class ActiveExportTracker {
+    private val activeExports: MutableSet<Long> = ConcurrentHashMap.newKeySet()
+
+    fun tryAcquire(chatId: Long): Boolean = activeExports.add(chatId)
+
+    fun release(chatId: Long) {
+        activeExports.remove(chatId)
+    }
+}

--- a/modules/telegram/src/main/kotlin/ru/zinin/frigate/analyzer/telegram/bot/handler/export/ExportCommandHandler.kt
+++ b/modules/telegram/src/main/kotlin/ru/zinin/frigate/analyzer/telegram/bot/handler/export/ExportCommandHandler.kt
@@ -1,0 +1,83 @@
+package ru.zinin.frigate.analyzer.telegram.bot.handler.export
+
+import dev.inmo.tgbotapi.extensions.api.send.reply
+import dev.inmo.tgbotapi.extensions.api.send.sendTextMessage
+import dev.inmo.tgbotapi.extensions.behaviour_builder.BehaviourContext
+import dev.inmo.tgbotapi.types.message.abstracts.CommonMessage
+import dev.inmo.tgbotapi.types.message.content.TextContent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import org.springframework.beans.factory.DisposableBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+import ru.zinin.frigate.analyzer.telegram.bot.handler.CommandHandler
+import ru.zinin.frigate.analyzer.telegram.model.UserRole
+import ru.zinin.frigate.analyzer.telegram.service.TelegramUserService
+
+@Component
+@ConditionalOnProperty(prefix = "application.telegram", name = ["enabled"], havingValue = "true")
+class ExportCommandHandler(
+    private val userService: TelegramUserService,
+    private val exportDialogRunner: ExportDialogRunner,
+    private val exportExecutor: ExportExecutor,
+    private val activeExportTracker: ActiveExportTracker,
+) : CommandHandler,
+    DisposableBean {
+    private val exportScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+    override val command: String = "export"
+    override val description: String = "Выгрузить видео"
+    override val requiredRole: UserRole = UserRole.USER
+    override val order: Int = 3
+
+    override suspend fun BehaviourContext.handle(
+        message: CommonMessage<TextContent>,
+        role: UserRole?,
+    ) {
+        val chatId = message.chat.id
+        val chatIdLong = chatId.chatId.long
+
+        if (!activeExportTracker.tryAcquire(chatIdLong)) {
+            reply(message, "Экспорт уже выполняется. Дождитесь завершения текущего экспорта.")
+            return
+        }
+
+        var releaseNeeded = true
+
+        try {
+            val userZone = userService.getUserZone(chatIdLong)
+            val outcome = with(exportDialogRunner) { runDialog(chatId, userZone) }
+
+            when (outcome) {
+                is ExportDialogOutcome.Success -> {
+                    releaseNeeded = false
+                    exportScope.launch {
+                        try {
+                            exportExecutor.execute(chatId, userZone, outcome)
+                        } finally {
+                            activeExportTracker.release(chatIdLong)
+                        }
+                    }
+                }
+
+                is ExportDialogOutcome.Cancelled -> {
+                }
+
+                is ExportDialogOutcome.Timeout -> {
+                    sendTextMessage(chatId, "Время ожидания истекло. Попробуйте снова /export.")
+                }
+            }
+        } finally {
+            if (releaseNeeded) {
+                activeExportTracker.release(chatIdLong)
+            }
+        }
+    }
+
+    override fun destroy() {
+        exportScope.cancel()
+    }
+}

--- a/modules/telegram/src/main/kotlin/ru/zinin/frigate/analyzer/telegram/bot/handler/export/ExportDialogRunner.kt
+++ b/modules/telegram/src/main/kotlin/ru/zinin/frigate/analyzer/telegram/bot/handler/export/ExportDialogRunner.kt
@@ -1,0 +1,274 @@
+package ru.zinin.frigate.analyzer.telegram.bot.handler.export
+
+import dev.inmo.tgbotapi.extensions.api.answers.answer
+import dev.inmo.tgbotapi.extensions.api.edit.reply_markup.editMessageReplyMarkup
+import dev.inmo.tgbotapi.extensions.api.send.sendTextMessage
+import dev.inmo.tgbotapi.extensions.behaviour_builder.BehaviourContext
+import dev.inmo.tgbotapi.extensions.behaviour_builder.expectations.waitDataCallbackQuery
+import dev.inmo.tgbotapi.extensions.behaviour_builder.expectations.waitTextMessage
+import dev.inmo.tgbotapi.types.IdChatIdentifier
+import dev.inmo.tgbotapi.types.buttons.InlineKeyboardButtons.CallbackDataInlineKeyboardButton
+import dev.inmo.tgbotapi.types.buttons.InlineKeyboardMarkup
+import dev.inmo.tgbotapi.types.queries.callback.MessageDataCallbackQuery
+import dev.inmo.tgbotapi.utils.matrix
+import dev.inmo.tgbotapi.utils.row
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+import ru.zinin.frigate.analyzer.telegram.service.VideoExportService
+import ru.zinin.frigate.analyzer.telegram.service.model.ExportMode
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+import java.time.temporal.ChronoUnit
+
+@Component
+@ConditionalOnProperty(prefix = "application.telegram", name = ["enabled"], havingValue = "true")
+class ExportDialogRunner(
+    private val videoExportService: VideoExportService,
+    private val clock: Clock,
+) {
+    @Suppress("LongMethod")
+    suspend fun BehaviourContext.runDialog(
+        chatId: IdChatIdentifier,
+        userZone: ZoneId,
+    ): ExportDialogOutcome =
+        withTimeoutOrNull(EXPORT_DIALOG_TIMEOUT_MS) {
+            val dateKeyboard =
+                InlineKeyboardMarkup(
+                    keyboard =
+                        matrix {
+                            row {
+                                +CallbackDataInlineKeyboardButton("Сегодня", "export:today")
+                                +CallbackDataInlineKeyboardButton("Вчера", "export:yesterday")
+                            }
+                            row {
+                                +CallbackDataInlineKeyboardButton("Ввести дату", "export:custom")
+                                +CallbackDataInlineKeyboardButton("Отмена", "export:cancel")
+                            }
+                        },
+                )
+
+            val dateSentMessage = sendTextMessage(chatId, "Выберите дату:", replyMarkup = dateKeyboard)
+
+            val dateCallback =
+                waitDataCallbackQuery()
+                    .filter {
+                        it.data.startsWith("export:") &&
+                            (it as? MessageDataCallbackQuery)?.message?.let { msg ->
+                                msg.messageId == dateSentMessage.messageId && msg.chat.id == chatId
+                            } == true
+                    }.first()
+            answer(dateCallback)
+            try {
+                editMessageReplyMarkup(dateSentMessage, replyMarkup = null)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+            }
+
+            if (dateCallback.data == "export:cancel") {
+                sendTextMessage(chatId, "Экспорт отменён.")
+                return@withTimeoutOrNull ExportDialogOutcome.Cancelled
+            }
+
+            val date: LocalDate =
+                when (dateCallback.data) {
+                    "export:today" -> {
+                        Instant.now(clock).atZone(userZone).toLocalDate()
+                    }
+
+                    "export:yesterday" -> {
+                        Instant
+                            .now(clock)
+                            .atZone(userZone)
+                            .toLocalDate()
+                            .minusDays(1)
+                    }
+
+                    "export:custom" -> {
+                        sendTextMessage(chatId, "Введите дату (формат: YYYY-MM-DD) или /cancel для отмены:")
+                        val dateMsg =
+                            waitTextMessage()
+                                .filter { it.chat.id == chatId }
+                                .first()
+                        val dateInput = dateMsg.content.text.trim()
+                        if (dateInput == "/cancel" || dateInput.equals("отмена", ignoreCase = true)) {
+                            sendTextMessage(chatId, "Экспорт отменён.")
+                            return@withTimeoutOrNull ExportDialogOutcome.Cancelled
+                        }
+                        try {
+                            LocalDate.parse(dateInput)
+                        } catch (e: DateTimeParseException) {
+                            sendTextMessage(chatId, "Неверный формат даты. Используйте YYYY-MM-DD. Экспорт отменён.")
+                            return@withTimeoutOrNull ExportDialogOutcome.Cancelled
+                        }
+                    }
+
+                    else -> {
+                        return@withTimeoutOrNull ExportDialogOutcome.Cancelled
+                    }
+                }
+
+            sendTextMessage(
+                chatId,
+                "Введите диапазон времени (например: 9:15-9:20, макс. 5 минут)\nВремя в вашем часовом поясе: $userZone\nИли /cancel:",
+            )
+            val timeMsg =
+                waitTextMessage()
+                    .filter { it.chat.id == chatId }
+                    .first()
+
+            val timeInput = timeMsg.content.text.trim()
+            if (timeInput == "/cancel" || timeInput.equals("отмена", ignoreCase = true)) {
+                sendTextMessage(chatId, "Экспорт отменён.")
+                return@withTimeoutOrNull ExportDialogOutcome.Cancelled
+            }
+
+            val timeRange = parseTimeRange(timeInput)
+            if (timeRange == null) {
+                sendTextMessage(chatId, "Неверный формат. Используйте H:MM-H:MM (например, 9:15-9:20). Экспорт отменён.")
+                return@withTimeoutOrNull ExportDialogOutcome.Cancelled
+            }
+
+            val (startTime, endTime) = timeRange
+            val durationMinutes = ChronoUnit.MINUTES.between(startTime, endTime)
+            if (durationMinutes > MAX_EXPORT_DURATION_MINUTES || durationMinutes <= 0) {
+                sendTextMessage(
+                    chatId,
+                    "Диапазон должен быть от 1 до $MAX_EXPORT_DURATION_MINUTES минут. Экспорт отменён.",
+                )
+                return@withTimeoutOrNull ExportDialogOutcome.Cancelled
+            }
+
+            val startInstant = LocalDateTime.of(date, startTime).atZone(userZone).toInstant()
+            val endInstant = LocalDateTime.of(date, endTime).atZone(userZone).toInstant()
+
+            val actualDuration = Duration.between(startInstant, endInstant)
+            if (actualDuration.isNegative || actualDuration.isZero || actualDuration.toMinutes() > MAX_EXPORT_DURATION_MINUTES) {
+                sendTextMessage(
+                    chatId,
+                    "Диапазон после конвертации в UTC превышает 5 минут " +
+                        "(возможно из-за перехода на летнее/зимнее время). Попробуйте другой диапазон.",
+                )
+                return@withTimeoutOrNull ExportDialogOutcome.Cancelled
+            }
+
+            val cameras = videoExportService.findCamerasWithRecordings(startInstant, endInstant)
+            if (cameras.isEmpty()) {
+                sendTextMessage(chatId, "Записей за $date $startTime-$endTime не найдено.")
+                return@withTimeoutOrNull ExportDialogOutcome.Cancelled
+            }
+
+            val cameraKeyboard =
+                InlineKeyboardMarkup(
+                    keyboard =
+                        matrix {
+                            cameras.forEach { cam ->
+                                row {
+                                    +CallbackDataInlineKeyboardButton(
+                                        "${cam.camId} (${cam.recordingsCount})",
+                                        "export:cam:${cam.camId}",
+                                    )
+                                }
+                            }
+                            row {
+                                +CallbackDataInlineKeyboardButton("Отмена", "export:cancel")
+                            }
+                        },
+                )
+
+            val camSentMessage = sendTextMessage(chatId, "Выберите камеру:", replyMarkup = cameraKeyboard)
+
+            val camCallback =
+                waitDataCallbackQuery()
+                    .filter {
+                        (it.data.startsWith("export:cam:") || it.data == "export:cancel") &&
+                            (it as? MessageDataCallbackQuery)?.message?.let { msg ->
+                                msg.messageId == camSentMessage.messageId && msg.chat.id == chatId
+                            } == true
+                    }.first()
+            answer(camCallback)
+            try {
+                editMessageReplyMarkup(camSentMessage, replyMarkup = null)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+            }
+
+            if (camCallback.data == "export:cancel") {
+                sendTextMessage(chatId, "Экспорт отменён.")
+                return@withTimeoutOrNull ExportDialogOutcome.Cancelled
+            }
+
+            val camId = camCallback.data.removePrefix("export:cam:")
+
+            val modeKeyboard =
+                InlineKeyboardMarkup(
+                    keyboard =
+                        matrix {
+                            row {
+                                +CallbackDataInlineKeyboardButton("Оригинал", "export:mode:original")
+                                +CallbackDataInlineKeyboardButton("С объектами", "export:mode:annotated")
+                            }
+                            row {
+                                +CallbackDataInlineKeyboardButton("Отмена", "export:cancel")
+                            }
+                        },
+                )
+
+            val modeSentMessage = sendTextMessage(chatId, "Выберите режим экспорта:", replyMarkup = modeKeyboard)
+
+            val modeCallback =
+                waitDataCallbackQuery()
+                    .filter {
+                        (it.data.startsWith("export:mode:") || it.data == "export:cancel") &&
+                            (it as? MessageDataCallbackQuery)?.message?.let { msg ->
+                                msg.messageId == modeSentMessage.messageId && msg.chat.id == chatId
+                            } == true
+                    }.first()
+            answer(modeCallback)
+            try {
+                editMessageReplyMarkup(modeSentMessage, replyMarkup = null)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+            }
+
+            if (modeCallback.data == "export:cancel") {
+                sendTextMessage(chatId, "Экспорт отменён.")
+                return@withTimeoutOrNull ExportDialogOutcome.Cancelled
+            }
+
+            val mode =
+                when (modeCallback.data) {
+                    "export:mode:annotated" -> ExportMode.ANNOTATED
+                    else -> ExportMode.ORIGINAL
+                }
+
+            ExportDialogOutcome.Success(startInstant, endInstant, camId, mode)
+        } ?: ExportDialogOutcome.Timeout
+
+    private fun parseTimeRange(input: String): Pair<LocalTime, LocalTime>? {
+        val parts = input.split("-", limit = 2)
+        if (parts.size != 2) return null
+
+        return try {
+            val formatter = DateTimeFormatter.ofPattern("H:mm")
+            val start = LocalTime.parse(parts[0].trim(), formatter)
+            val end = LocalTime.parse(parts[1].trim(), formatter)
+            start to end
+        } catch (e: DateTimeParseException) {
+            null
+        }
+    }
+}

--- a/modules/telegram/src/main/kotlin/ru/zinin/frigate/analyzer/telegram/bot/handler/export/ExportExecutor.kt
+++ b/modules/telegram/src/main/kotlin/ru/zinin/frigate/analyzer/telegram/bot/handler/export/ExportExecutor.kt
@@ -1,0 +1,146 @@
+package ru.zinin.frigate.analyzer.telegram.bot.handler.export
+
+import dev.inmo.tgbotapi.bot.TelegramBot
+import dev.inmo.tgbotapi.extensions.api.edit.text.editMessageText
+import dev.inmo.tgbotapi.extensions.api.send.media.sendVideo
+import dev.inmo.tgbotapi.extensions.api.send.sendTextMessage
+import dev.inmo.tgbotapi.requests.abstracts.asMultipartFile
+import dev.inmo.tgbotapi.types.IdChatIdentifier
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.withTimeoutOrNull
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+import ru.zinin.frigate.analyzer.telegram.config.TelegramProperties
+import ru.zinin.frigate.analyzer.telegram.service.VideoExportService
+import ru.zinin.frigate.analyzer.telegram.service.model.ExportMode
+import ru.zinin.frigate.analyzer.telegram.service.model.VideoExportProgress
+import ru.zinin.frigate.analyzer.telegram.service.model.VideoExportProgress.Stage
+import java.time.ZoneId
+
+private val logger = KotlinLogging.logger {}
+
+@Component
+@ConditionalOnProperty(prefix = "application.telegram", name = ["enabled"], havingValue = "true")
+class ExportExecutor(
+    private val bot: TelegramBot,
+    private val videoExportService: VideoExportService,
+    private val properties: TelegramProperties,
+) {
+    @Suppress("LongMethod")
+    suspend fun execute(
+        chatId: IdChatIdentifier,
+        userZone: ZoneId,
+        dialogResult: ExportDialogOutcome.Success,
+    ) {
+        val (startInstant, endInstant, camId, mode) = dialogResult
+
+        val statusMessage = bot.sendTextMessage(chatId, renderProgress(Stage.PREPARING, mode = mode))
+
+        var lastRenderedStage: Stage? = Stage.PREPARING
+        var lastRenderedPercent: Int? = null
+        var hadCompressing = false
+
+        val onProgress: suspend (VideoExportProgress) -> Unit = { progress ->
+            if (progress.stage == Stage.COMPRESSING) hadCompressing = true
+
+            val shouldUpdate =
+                when {
+                    progress.stage != lastRenderedStage -> {
+                        true
+                    }
+
+                    progress.stage == Stage.ANNOTATING && progress.percent != null -> {
+                        val lastPct = lastRenderedPercent ?: -1
+                        (progress.percent - lastPct) >= 5
+                    }
+
+                    else -> {
+                        false
+                    }
+                }
+
+            if (shouldUpdate) {
+                lastRenderedStage = progress.stage
+                lastRenderedPercent = progress.percent
+                try {
+                    bot.editMessageText(
+                        statusMessage,
+                        renderProgress(progress.stage, progress.percent, mode, hadCompressing),
+                    )
+                } catch (e: Exception) {
+                    logger.warn(e) { "Failed to update export progress message" }
+                }
+            }
+        }
+
+        try {
+            val processingTimeout =
+                if (mode == ExportMode.ANNOTATED) EXPORT_ANNOTATED_TIMEOUT_MS else EXPORT_ORIGINAL_TIMEOUT_MS
+            val videoPath =
+                withTimeoutOrNull(processingTimeout) {
+                    videoExportService.exportVideo(startInstant, endInstant, camId, mode, onProgress)
+                } ?: run {
+                    bot.sendTextMessage(chatId, "Обработка видео заняла слишком много времени. Попробуйте меньший диапазон.")
+                    return
+                }
+
+            try {
+                try {
+                    bot.editMessageText(statusMessage, renderProgress(Stage.SENDING, mode = mode, compressing = hadCompressing))
+                } catch (e: Exception) {
+                    logger.warn(e) { "Failed to update export progress message" }
+                }
+
+                val localDate = startInstant.atZone(userZone).toLocalDate()
+                val localStart = startInstant.atZone(userZone).toLocalTime()
+                val localEnd = endInstant.atZone(userZone).toLocalTime()
+                val fileName = "export_${camId}_${localDate}_$localStart-$localEnd.mp4".replace(":", "-")
+                val sent =
+                    withTimeoutOrNull(properties.sendVideoTimeout.toMillis()) {
+                        bot.sendVideo(
+                            chatId,
+                            videoPath.toFile().asMultipartFile().copy(filename = fileName),
+                        )
+                    }
+
+                if (sent == null) {
+                    logger.error {
+                        "Telegram sendVideo timed out after ${properties.sendVideoTimeout} " +
+                            "for chat=$chatId, camera=$camId, file=$fileName"
+                    }
+                    bot.sendTextMessage(
+                        chatId,
+                        "Не удалось отправить видео: превышено время ожидания " +
+                            "(${properties.sendVideoTimeout.toSeconds()} сек). " +
+                            "Возможно, проблемы с сетью. Попробуйте позже.",
+                    )
+                    return
+                }
+
+                try {
+                    bot.editMessageText(statusMessage, renderProgress(Stage.DONE, mode = mode, compressing = hadCompressing))
+                } catch (e: Exception) {
+                    logger.warn(e) { "Failed to update export progress message" }
+                }
+            } finally {
+                try {
+                    videoExportService.cleanupExportFile(videoPath)
+                } catch (e: Exception) {
+                    logger.warn(e) { "Failed to delete temp file: $videoPath" }
+                }
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.error(e) { "Video export failed" }
+            val errorText =
+                if (mode == ExportMode.ANNOTATED) {
+                    "Ошибка экспорта видео с объектами. Попробуйте обычный режим или другие параметры."
+                } else {
+                    "Ошибка экспорта видео. Попробуйте меньший диапазон или другую камеру."
+                }
+            bot.sendTextMessage(chatId, errorText)
+        }
+    }
+}

--- a/modules/telegram/src/main/kotlin/ru/zinin/frigate/analyzer/telegram/bot/handler/export/ExportModels.kt
+++ b/modules/telegram/src/main/kotlin/ru/zinin/frigate/analyzer/telegram/bot/handler/export/ExportModels.kt
@@ -1,0 +1,55 @@
+package ru.zinin.frigate.analyzer.telegram.bot.handler.export
+
+import ru.zinin.frigate.analyzer.telegram.service.model.ExportMode
+import ru.zinin.frigate.analyzer.telegram.service.model.VideoExportProgress.Stage
+import java.time.Instant
+
+sealed class ExportDialogOutcome {
+    data class Success(
+        val startInstant: Instant,
+        val endInstant: Instant,
+        val camId: String,
+        val mode: ExportMode,
+    ) : ExportDialogOutcome()
+
+    data object Cancelled : ExportDialogOutcome()
+
+    data object Timeout : ExportDialogOutcome()
+}
+
+internal const val EXPORT_DIALOG_TIMEOUT_MS = 600_000L
+internal const val EXPORT_ORIGINAL_TIMEOUT_MS = 300_000L
+internal const val EXPORT_ANNOTATED_TIMEOUT_MS = 1_200_000L
+internal const val MAX_EXPORT_DURATION_MINUTES = 5L
+
+internal fun renderProgress(
+    stage: Stage,
+    percent: Int? = null,
+    mode: ExportMode = ExportMode.ORIGINAL,
+    compressing: Boolean = false,
+): String {
+    val stages =
+        buildList {
+            add(Stage.PREPARING to "Подготовка")
+            add(Stage.MERGING to "Склейка видео")
+            if (compressing) add(Stage.COMPRESSING to "Сжатие видео")
+            if (mode == ExportMode.ANNOTATED) add(Stage.ANNOTATING to "Аннотация видео")
+            add(Stage.SENDING to "Отправка")
+            add(Stage.DONE to "Готово")
+        }
+
+    val currentIndex = stages.indexOfFirst { it.first == stage }
+
+    return buildString {
+        for ((index, pair) in stages.withIndex()) {
+            val (s, label) = pair
+            when {
+                s == stage && s == Stage.DONE -> appendLine("\u2705 $label")
+                s == stage && s == Stage.ANNOTATING && percent != null -> appendLine("\uD83D\uDD04 $label: $percent%")
+                s == stage -> appendLine("\uD83D\uDD04 $label...")
+                currentIndex >= 0 && index < currentIndex -> appendLine("\u2705 $label")
+                else -> appendLine("\u2B1C $label")
+            }
+        }
+    }.trimEnd()
+}

--- a/modules/telegram/src/main/kotlin/ru/zinin/frigate/analyzer/telegram/filter/AuthorizationFilter.kt
+++ b/modules/telegram/src/main/kotlin/ru/zinin/frigate/analyzer/telegram/filter/AuthorizationFilter.kt
@@ -39,11 +39,6 @@ class AuthorizationFilter(
         }
     }
 
-    fun isOwner(message: CommonMessage<MessageContent>): Boolean {
-        val username = extractUsername(message) ?: return false
-        return username == properties.owner
-    }
-
     fun extractUsername(message: CommonMessage<MessageContent>): String? {
         val privateMessage = message as? PrivateContentMessage<*> ?: return null
         return privateMessage.user.username?.withoutAt

--- a/modules/telegram/src/test/kotlin/ru/zinin/frigate/analyzer/telegram/bot/handler/export/ActiveExportTrackerTest.kt
+++ b/modules/telegram/src/test/kotlin/ru/zinin/frigate/analyzer/telegram/bot/handler/export/ActiveExportTrackerTest.kt
@@ -1,0 +1,33 @@
+package ru.zinin.frigate.analyzer.telegram.bot.handler.export
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ActiveExportTrackerTest {
+    private val tracker = ActiveExportTracker()
+
+    @Test
+    fun `tryAcquire returns true for first call`() {
+        assertTrue(tracker.tryAcquire(123L))
+    }
+
+    @Test
+    fun `tryAcquire returns false for second call with same chatId`() {
+        tracker.tryAcquire(123L)
+        assertFalse(tracker.tryAcquire(123L))
+    }
+
+    @Test
+    fun `tryAcquire returns true for different chatIds`() {
+        assertTrue(tracker.tryAcquire(123L))
+        assertTrue(tracker.tryAcquire(456L))
+    }
+
+    @Test
+    fun `release allows re-acquire`() {
+        tracker.tryAcquire(123L)
+        tracker.release(123L)
+        assertTrue(tracker.tryAcquire(123L))
+    }
+}

--- a/modules/telegram/src/test/kotlin/ru/zinin/frigate/analyzer/telegram/bot/handler/export/ExportModelsTest.kt
+++ b/modules/telegram/src/test/kotlin/ru/zinin/frigate/analyzer/telegram/bot/handler/export/ExportModelsTest.kt
@@ -1,0 +1,40 @@
+package ru.zinin.frigate.analyzer.telegram.bot.handler.export
+
+import org.junit.jupiter.api.Test
+import ru.zinin.frigate.analyzer.telegram.service.model.ExportMode
+import ru.zinin.frigate.analyzer.telegram.service.model.VideoExportProgress.Stage
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ExportModelsTest {
+    @Test
+    fun `renderProgress shows preparing stage`() {
+        val result = renderProgress(Stage.PREPARING)
+        assertContains(result, "Подготовка")
+    }
+
+    @Test
+    fun `renderProgress shows done stage with checkmarks`() {
+        val result = renderProgress(Stage.DONE)
+        assertTrue(result.contains("✅"))
+    }
+
+    @Test
+    fun `renderProgress shows annotating percent`() {
+        val result = renderProgress(Stage.ANNOTATING, percent = 42, mode = ExportMode.ANNOTATED)
+        assertContains(result, "42%")
+    }
+
+    @Test
+    fun `renderProgress includes compression stage when compressing`() {
+        val result = renderProgress(Stage.COMPRESSING, compressing = true)
+        assertContains(result, "Сжатие видео")
+    }
+
+    @Test
+    fun `renderProgress omits compression stage when not compressing`() {
+        val result = renderProgress(Stage.MERGING)
+        assertFalse(result.contains("Сжатие видео"))
+    }
+}


### PR DESCRIPTION
## Summary

Refactoring of the 967-line `FrigateAnalyzerBot` into focused command handler classes using the Command Handler pattern.

### Changes

- **CommandHandler interface** — unified interface for all bot commands with metadata (command, description, requiredRole, ownerOnly, order)
- **8 command handlers** — Start, Help, Export, Timezone, Version, AddUser, RemoveUser, Users
- **Export decomposition** — ExportDialogRunner, ExportExecutor, ActiveExportTracker, ExportModels
- **OwnerActivatedEvent** — Spring event for owner menu registration
- **Thin orchestrator** — FrigateAnalyzerBot now ~166 lines (routing, auth, lifecycle only)

### Testing

- ActiveExportTracker: 4 unit tests
- ExportModels (renderProgress): 5 unit tests
- All 95 tests pass

### Code Review Fixes

- CancellationException rethrow in catch blocks (proper coroutine cancellation)
- Timeout on TimezoneCommandHandler interactive dialog
- Removed unused TelegramBot DI from handlers

### Related

- FA-23